### PR TITLE
fix: ensure published package works under Node.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: bun run test
+        run: bun test --timeout 30000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: bun test
+        run: bun run test

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { loadConfig, mergeConfig } from "./config";
-import { formatInitResult, initProject } from "./init";
-import { parseFlowFile } from "./parser";
-import { formatResult, formatSummary } from "./reporter";
-import { DEFAULT_TIMEOUT, runFlow } from "./runner";
-import type { FlowResult, FlowSpec } from "./types";
+import { loadConfig, mergeConfig } from "./config.js";
+import { formatInitResult, initProject } from "./init.js";
+import { parseFlowFile } from "./parser.js";
+import { formatResult, formatSummary } from "./reporter.js";
+import { DEFAULT_TIMEOUT, runFlow } from "./runner.js";
+import type { FlowResult, FlowSpec } from "./types.js";
 
 interface CliOptions {
   path?: string;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import yaml from "js-yaml";
 import type { ZodError } from "zod";
-import { type FlowSpec, FlowSpecSchema } from "./types";
+import { type FlowSpec, FlowSpecSchema } from "./types.js";
 
 /**
  * Format a Zod validation error into a human-readable message

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,4 +1,4 @@
-import type { FlowError, FlowResult, StepAction } from "./types";
+import type { FlowError, FlowResult, StepAction } from "./types.js";
 
 // ANSI color codes
 const GREEN = "\x1b[32m";

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -10,7 +10,8 @@ import type {
 
 // Declare minimal Bun types for TypeScript when running in Bun runtime
 declare global {
-  const Bun:
+  // eslint-disable-next-line no-var
+  var Bun:
     | {
         spawn: (
           cmd: string[],
@@ -106,8 +107,10 @@ async function execCommand(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   // Check if Bun.spawn is available (running in Bun runtime)
-  if (Bun?.spawn) {
-    const proc = Bun.spawn([binPath, ...args], {
+  // Use globalThis to avoid ReferenceError under Node.js where Bun is undeclared
+  const BunRuntime = globalThis.Bun;
+  if (BunRuntime?.spawn) {
+    const proc = BunRuntime.spawn([binPath, ...args], {
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -6,7 +6,7 @@ import type {
   FlowSpec,
   StepAction,
   StepAssertion,
-} from "./types";
+} from "./types.js";
 
 // Declare minimal Bun types for TypeScript when running in Bun runtime
 declare global {

--- a/test/cli-timeout.test.ts
+++ b/test/cli-timeout.test.ts
@@ -150,13 +150,10 @@ describe("CLI --timeout flag", () => {
       }
     });
 
-    it(
-      "should use default timeout when --timeout is not specified",
-      { timeout: 30000 },
-      async () => {
-        // Create a valid flow file that visits a page with no assertions
-        // so it completes quickly even with default timeout
-        const flowYaml = `
+    it("should use default timeout when --timeout is not specified", async () => {
+      // Create a valid flow file that visits a page with no assertions
+      // so it completes quickly even with default timeout
+      const flowYaml = `
 name: timeout-test
 description: Test flow for timeout passthrough
 steps:
@@ -164,15 +161,14 @@ steps:
 expect:
   - visible: Test
 `;
-        const filePath = join(tempDir, "timeout-test.flow.yaml");
-        writeFileSync(filePath, flowYaml);
+      const filePath = join(tempDir, "timeout-test.flow.yaml");
+      writeFileSync(filePath, flowYaml);
 
-        const result = await runCLI(["run", filePath], { timeout: 15000 });
+      const result = await runCLI(["run", filePath], { timeout: 15000 });
 
-        // Should run without parse errors (runner may fail due to no server)
-        expect(result.exitCode).not.toBe(2);
-      },
-    );
+      // Should run without parse errors (runner may fail due to no server)
+      expect(result.exitCode).not.toBe(2);
+    });
 
     it("should accept timeout value of 0", async () => {
       const flowFile = join(VALID_FLOWS_DIR, "login.flow.yaml");

--- a/test/runner-retry.test.ts
+++ b/test/runner-retry.test.ts
@@ -26,115 +26,98 @@ describeIfAgentBrowser("assertion retry", () => {
     await server.stop();
   });
 
-  it(
-    "should retry visible assertion until content appears",
-    { timeout: 30000 },
-    async () => {
-      // delayed.html shows "Delayed Content Loaded" after 3000ms
-      // With 10s timeout, this should pass after retrying
-      const flow: FlowSpec = {
-        name: "retry-until-visible",
-        description:
-          "Test that assertion retries until delayed content appears",
-        steps: [{ visit: "/delayed.html" }],
-        expect: [{ visible: "Delayed Content Loaded" }],
-      };
+  it("should retry visible assertion until content appears", async () => {
+    // delayed.html shows "Delayed Content Loaded" after 3000ms
+    // With 10s timeout, this should pass after retrying
+    const flow: FlowSpec = {
+      name: "retry-until-visible",
+      description: "Test that assertion retries until delayed content appears",
+      steps: [{ visit: "/delayed.html" }],
+      expect: [{ visible: "Delayed Content Loaded" }],
+    };
 
-      const result = await runFlow(flow, {
-        baseUrl: server.baseUrl,
-        timeout: 10000, // 10 seconds is plenty for 3s delay
-      });
+    const result = await runFlow(flow, {
+      baseUrl: server.baseUrl,
+      timeout: 10000, // 10 seconds is plenty for 3s delay
+    });
 
-      expect(result.success).toBe(true);
-      // Duration should be at least 3000ms (time for content to appear)
-      expect(result.duration).toBeGreaterThanOrEqual(3000);
-    },
-  );
+    expect(result.success).toBe(true);
+    // Duration should be at least 3000ms (time for content to appear)
+    expect(result.duration).toBeGreaterThanOrEqual(3000);
+  });
 
-  it(
-    "should timeout and fail when content never appears",
-    { timeout: 30000 },
-    async () => {
-      // Use login.html which never has the delayed content text
-      const flow: FlowSpec = {
-        name: "timeout-never-appears",
-        description:
-          "Test that assertion fails after timeout when text never appears",
-        steps: [{ visit: "/login.html" }],
-        expect: [{ visible: "Delayed Content Loaded" }],
-      };
+  it("should timeout and fail when content never appears", async () => {
+    // Use login.html which never has the delayed content text
+    const flow: FlowSpec = {
+      name: "timeout-never-appears",
+      description:
+        "Test that assertion fails after timeout when text never appears",
+      steps: [{ visit: "/login.html" }],
+      expect: [{ visible: "Delayed Content Loaded" }],
+    };
 
-      const startTime = Date.now();
-      const result = await runFlow(flow, {
-        baseUrl: server.baseUrl,
-        timeout: 500, // Short timeout
-      });
-      const elapsed = Date.now() - startTime;
+    const startTime = Date.now();
+    const result = await runFlow(flow, {
+      baseUrl: server.baseUrl,
+      timeout: 500, // Short timeout
+    });
+    const elapsed = Date.now() - startTime;
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-      expect(result.error?.assertion).toEqual({
-        visible: "Delayed Content Loaded",
-      });
-      // Should have waited approximately the timeout duration before failing
-      expect(elapsed).toBeGreaterThanOrEqual(500);
-    },
-  );
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.assertion).toEqual({
+      visible: "Delayed Content Loaded",
+    });
+    // Should have waited approximately the timeout duration before failing
+    expect(elapsed).toBeGreaterThanOrEqual(500);
+  });
 
-  it(
-    "should fail when custom timeout is shorter than content delay",
-    { timeout: 30000 },
-    async () => {
-      // delayed.html shows content after 3000ms
-      // With 500ms timeout, should fail before content appears
-      const flow: FlowSpec = {
-        name: "custom-timeout-too-short",
-        description: "Test that custom timeout is respected",
-        steps: [{ visit: "/delayed.html" }],
-        expect: [{ visible: "Delayed Content Loaded" }],
-      };
+  it("should fail when custom timeout is shorter than content delay", async () => {
+    // delayed.html shows content after 3000ms
+    // With 500ms timeout, should fail before content appears
+    const flow: FlowSpec = {
+      name: "custom-timeout-too-short",
+      description: "Test that custom timeout is respected",
+      steps: [{ visit: "/delayed.html" }],
+      expect: [{ visible: "Delayed Content Loaded" }],
+    };
 
-      const result = await runFlow(flow, {
-        baseUrl: server.baseUrl,
-        timeout: 500, // Much shorter than 3000ms page delay
-      });
+    const result = await runFlow(flow, {
+      baseUrl: server.baseUrl,
+      timeout: 500, // Much shorter than 3000ms page delay
+    });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-      expect(result.error?.assertion).toEqual({
-        visible: "Delayed Content Loaded",
-      });
-    },
-  );
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.assertion).toEqual({
+      visible: "Delayed Content Loaded",
+    });
+  });
 
-  it(
-    "should fail immediately with timeout: 0 (no retry)",
-    { timeout: 30000 },
-    async () => {
-      // delayed.html shows content after 3000ms
-      // With timeout: 0, should fail on first check without any retry
-      const flow: FlowSpec = {
-        name: "no-retry-immediate-fail",
-        description: "Test that timeout:0 disables retry",
-        steps: [{ visit: "/delayed.html" }],
-        expect: [{ visible: "Delayed Content Loaded" }],
-      };
+  it("should fail immediately with timeout: 0 (no retry)", async () => {
+    // delayed.html shows content after 3000ms
+    // With timeout: 0, should fail on first check without any retry
+    const flow: FlowSpec = {
+      name: "no-retry-immediate-fail",
+      description: "Test that timeout:0 disables retry",
+      steps: [{ visit: "/delayed.html" }],
+      expect: [{ visible: "Delayed Content Loaded" }],
+    };
 
-      const startTime = Date.now();
-      const result = await runFlow(flow, {
-        baseUrl: server.baseUrl,
-        timeout: 0,
-      });
-      const elapsed = Date.now() - startTime;
+    const startTime = Date.now();
+    const result = await runFlow(flow, {
+      baseUrl: server.baseUrl,
+      timeout: 0,
+    });
+    const elapsed = Date.now() - startTime;
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
-      expect(result.error?.assertion).toEqual({
-        visible: "Delayed Content Loaded",
-      });
-      // Should fail without waiting for the 3000ms content delay
-      // Allow margin for browser operations (snapshot takes ~1s)
-      expect(elapsed).toBeLessThan(3000);
-    },
-  );
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.assertion).toEqual({
+      visible: "Delayed Content Loaded",
+    });
+    // Should fail without waiting for the 3000ms content delay
+    // Allow margin for browser operations (snapshot takes ~1s)
+    expect(elapsed).toBeLessThan(3000);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

- **Shebang**: Changed `#!/usr/bin/env bun` to `#!/usr/bin/env node` so the CLI runs without requiring bun at runtime
- **Module resolution**: Switched tsconfig from `bundler` to `NodeNext` so tsc emits Node-compatible ESM
- **Import extensions**: Added `.js` extensions to all 9 relative imports across `index.ts`, `parser.ts`, `reporter.ts`, and `runner.ts`

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun test` — all 234 tests pass
- [x] `bun run build` — produces `dist/`
- [x] `dist/index.js` shebang is `#!/usr/bin/env node`
- [x] All relative imports in `dist/` end in `.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated module import resolution for ESM/NodeNext compatibility.
  * Modified the project entry point to use a Node-compatible shebang.
  * Adjusted TypeScript config to NodeNext module/resolution.
  * Improved runtime compatibility so the tool runs cleanly in Node and Bun environments.
* **Tests**
  * CI test step now runs tests with a 30s timeout.
  * Refactored test cases for clearer, equivalent async/test structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->